### PR TITLE
strip newlines from twitter embed

### DIFF
--- a/lib/jekyll-twitter-plugin.rb
+++ b/lib/jekyll-twitter-plugin.rb
@@ -179,6 +179,7 @@ module TwitterJekyll
     # @api private
     def html_output_for(response)
       body = (response.html if response) || ERROR_BODY_TEXT
+      body = body.delete!("\n")
 
       "<div class='jekyll-twitter-plugin'>#{body}</div>"
     end


### PR DESCRIPTION
Not sure if this is the best way of handling it, but it worked for me. Background on this is that Jekyll was choking on the newline when a tweet was included as part of a list item, causing the list to close early and leaving a dangling `</div>`

The Twitter embed comes back with `\n` between the blockquote and the script. For whatever reason Jekyll hated this. ¯\_(ツ)_/¯