### PR TITLE
updated twitter documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,15 @@ The Twitter URLs that are supported depend on Twitter. We pass the url and all p
 
 ##### Timeline:
 
+* [https://developer.twitter.com/en/docs/twitter-for-websites/timelines/overview](https://developer.twitter.com/en/docs/twitter-for-websites/timelines/overview)
 * [https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/oembed-api](https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/oembed-api)
+* [https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/parameter-reference](https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/parameter-reference)
 
 ##### Moments:
 
 * [https://developer.twitter.com/en/docs/twitter-for-websites/moments/overview](https://developer.twitter.com/en/docs/twitter-for-websites/moments/overview)
+* [https://developer.twitter.com/en/docs/twitter-for-websites/moments/guides/oembed-api](https://developer.twitter.com/en/docs/twitter-for-websites/moments/guides/oembed-api)
+* [https://developer.twitter.com/en/docs/twitter-for-websites/moments/guides/parameter-reference0](https://developer.twitter.com/en/docs/twitter-for-websites/moments/guides/parameter-reference0)
 
 ### Customisation
 

--- a/README.md
+++ b/README.md
@@ -130,17 +130,17 @@ The Twitter URLs that are supported depend on Twitter. We pass the url and all p
 
 ##### Tweet:
 
-* [https://dev.twitter.com/web/overview](https://dev.twitter.com/web/overview)
-* [https://dev.twitter.com/rest/reference/get/statuses/oembed](https://dev.twitter.com/rest/reference/get/statuses/oembed)
-* [https://dev.twitter.com/web/embedded-tweets/parameters](https://dev.twitter.com/web/embedded-tweets/parameters)
+* [https://developer.twitter.com/en/docs/twitter-for-websites/overview](https://developer.twitter.com/en/docs/twitter-for-websites/overview)
+* [https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-oembed](https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-oembed)
+* [https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference](https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference)
 
 ##### Timeline:
 
-* [https://dev.twitter.com/web/embedded-timelines/oembed](https://dev.twitter.com/web/embedded-timelines/oembed)
+* [https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/oembed-api](https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/oembed-api)
 
 ##### Moments:
 
-* [https://dev.twitter.com/web/embedded-moments/oembed](https://dev.twitter.com/web/embedded-moments/oembed)
+* [https://developer.twitter.com/en/docs/twitter-for-websites/moments/overview](https://developer.twitter.com/en/docs/twitter-for-websites/moments/overview)
 
 ### Customisation
 


### PR DESCRIPTION
The links to various sub-pages in the Twitter documentation were broken in the README file. I've updated the file with links to what seem to be the nearest approximations of the previous pages. 
Previously, the Tweets API got three documentation links (overview, oembed, parameters), but only oembed for Timelines and Moments. I've added links so all three links appear for each API.